### PR TITLE
Fix Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM frekele/ant:1.10-jdk8 as builder
 
 WORKDIR /usr/local
-RUN curl --location 'https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.14/bin/apache-tomcat-9.0.14.tar.gz' | tar xz
+RUN curl --location 'https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.58/bin/apache-tomcat-9.0.58.tar.gz' | tar xz
 RUN cd apache-tomcat* && echo "catalina.home=$(pwd)" > ~/build.properties
 
 COPY . /tmp/joai-project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM frekele/ant:1.10-jdk8 as builder
 
 WORKDIR /usr/local
-RUN curl --location 'http://apache.mirror.digitalpacific.com.au/tomcat/tomcat-9/v9.0.14/bin/apache-tomcat-9.0.14.tar.gz' | tar xz
+RUN curl --location 'https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.14/bin/apache-tomcat-9.0.14.tar.gz' | tar xz
 RUN cd apache-tomcat* && echo "catalina.home=$(pwd)" > ~/build.properties
 
 COPY . /tmp/joai-project


### PR DESCRIPTION
Currently, the build fails [here](https://github.com/NCAR/joai-project/blob/25c00ccc7d63c2c3a3c673a321be6a21bc474b78/Dockerfile#L4) due of link rot. This PR fixes the issue by using a "archive" URL that is unlikely to break. It also makes the download more secure by using HTTPS, and bumps Tomcat to the latest 9.x version as of this writing (9.0.58).