### PR TITLE
Fix Docker Volume Declarations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,8 @@ RUN \
   ln -s /joai/config/harvester /usr/local/tomcat/webapps/ROOT/WEB-INF/harvester_settings_and_data && \
   ln -s /joai/config/repository /usr/local/tomcat/webapps/ROOT/WEB-INF/repository_settings_and_data
 
-VOLUME /joai/config  # just the config
-VOLUME /joai/data    # the harvested/provided records
+# just the config
+VOLUME /joai/config
+
+# the harvested/provided records
+VOLUME /joai/data


### PR DESCRIPTION
This pull request fixes an issue with the Docker volume declarations.

While most languages interpret the idom `statement #comment` correctly, Dockerfiles don't seem to allow this within volume declarations. This results in the unintended creation of the `#`, `the`, `just` etc. volumes for all running instances of this container (at least when built/run through `podman`).

To illustrate this issue, I've run `podman inspect` on the joai image, which yields:
```json
"Volumes": {
  "#": {},
  "/joai/config": {},
  "/joai/data": {},
  "config": {},
  "harvested/provided": {},
  "just": {},
  "records": {},
  "the": {}
}
```

Thank You for providing and maintaining this project and best regards!