### PR TITLE
Fixed baseUrl, support for x-forwarded-proto and x-forwarded-port

### DIFF
--- a/src/org/dlese/dpc/webapps/tools/GeneralServletTools.java
+++ b/src/org/dlese/dpc/webapps/tools/GeneralServletTools.java
@@ -85,15 +85,26 @@ public final class GeneralServletTools {
 	public static String getContextUrl(HttpServletRequest req) {
 		if (req == null)
 			return null;
+		String scheme = req.getScheme();
+		String forwardedProto = req.getHeader("x-forwarded-proto");
+		if (forwardedProto != null) {
+			scheme = forwardedProto;
+		}
+		String serverPort = String.valueOf(req.getServerPort());
+		String forwardedPort = req.getHeader("x-forwarded-port");
+		if (forwardedPort != null) {
+			serverPort = forwardedPort;
+		}
+		String portPart = ":" + serverPort;
+		if ("80".equals(serverPort) & scheme.equals("http") || 
+			"443".equals(serverPort) && scheme.equals("https")) {
+			portPart = "";
+		}
 
-		String port = "";
-		if (req.getServerPort() != 80)
-			port = ":" + req.getServerPort();
-
-		String contextURL = (req.getScheme()
+		String contextURL = (scheme
 				 + "://"
 				 + req.getServerName()
-				 + port
+				 + portPart
 				 + req.getContextPath()).trim();
 		return contextURL;
 	}


### PR DESCRIPTION
Current issues:

- If the scheme is https 443 port is included in base url, which is unnecessary.
- X-Forwarded-Port and X-Forwarded-Proto request headers are not supported, which makes proxy configuration much more complicated.

Solution:

- This PR adds support for X-Forwarded-Proto and  X-Forwarded-Port request headers to provide external scheme and port to be used for configurations behind proxy.
- Removed excessive ":443" port in base url in case the scheme is https